### PR TITLE
v0.2.3 feature update: create task - persist on page

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,3 +19,7 @@ v.0.2.0 feat: UI add task button
  - Created tasks are stored in memory and rendered in a simple list (title only)
  - new task button opens taskform modal and creates an event
 
+v.0.2.3  feature update: create task - persist on page
+- implement local storage for task persistenece
+- load tasks onto the web page
+- time stamp to display newest tasks at the top of list (to be replaced with priority function in the future)

--- a/components/App.js
+++ b/components/App.js
@@ -9,35 +9,50 @@ const App = {
       
       <!-- Main content -->
       <main>
-        <div class="flex justify-end mb-4">
+          <div class="flex justify-end mb-4">
             <button class="px-4 py-2 rounded-lg bg-emerald-600 text-white font-semibold"
                     @click="openForm">New Task</button>
-        </div>
+          </div>
 
-        <p class="text-gray-500 text-center">Task creation coming.</p>
+          <task-form v-if="showForm"
+                     @close="showForm=false"
+                     @create="onCreate"></task-form>
 
-        <!-- Add TaskForm component here -->
-        <task-form v-if="showForm" @close="showForm = false" @create="onCreate"></task-form>
-
-      </main>
+          <ul v-if="tasks.length" class="space-y-3">
+            <li v-for="t in tasks" :key="t.id" class="bg-white border rounded-xl p-3">
+              <div class="font-semibold">{{ t.title }}</div>
+            </li>
+          </ul>
+          <p v-else class="text-gray-500 text-center">No tasks yet. Click “New Task”.</p>
+        </main>
     </div>
   `,
     components: { 'task-form': TaskForm },
     data(){
       return {
         showForm: false,
-        tasks: []   // in-memory for now
+        tasks: this.loadTasks()   // in-memory for now
       };
         // TODO: Add your components here
         //'example': ExampleComponent
     },
     methods:{
       openForm(){ this.showForm = true; },
+      uid(){ return Math.random().toString(36).slice(2) + Date.now().toString(36); },
+      saveTasks(){ localStorage.setItem('scu.todo.tasks.v1', JSON.stringify(this.tasks)); },
+      loadTasks(){ try { return JSON.parse(localStorage.getItem('scu.todo.tasks.v1') || '[]'); } catch { return []; } },
       onCreate(payload){
         const title = String(payload.title || '').trim();
         if (!title) return;
-        const task = { id: Math.random().toString(36).slice(2), title };
-        this.tasks = [task, ...this.tasks];
+
+        const task = {
+          id: this.uid(),
+          title,
+          createdAt: new Date().toISOString()
+        };
+
+        this.tasks = [task, ...this.tasks].sort((a,b) => new Date(b.createdAt || 0) - new Date(a.createdAt || 0));
+        this.saveTasks();
         this.showForm = false;
       }
     }


### PR DESCRIPTION
Presents tasks onto the page with newly presented tasks at the top of the list, tasks persist in local storage and tasks now display but update to the styling needed